### PR TITLE
feat: Add GitHub Action to build debug APK

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -1,0 +1,39 @@
+name: Android CI Build Debug APK
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build_debug_apk:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up JDK 11
+      uses: actions/setup-java@v4
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+        cache: 'gradle' # Cache Gradle dependencies based on Java version
+
+    - name: Set up Gradle and cache dependencies
+      uses: gradle/actions/setup-gradle@v3 # This action handles caching and uses the wrapper
+
+    - name: Make gradlew executable
+      run: chmod +x ./gradlew
+
+    - name: Build debug APK
+      run: ./gradlew :app:assembleDebug
+
+    - name: Upload Debug APK
+      uses: actions/upload-artifact@v4
+      with:
+        name: debug-apk
+        path: app/build/outputs/apk/debug/app-debug.apk
+        if-no-files-found: error # Fail the workflow if the APK is not found
+        retention-days: 7 # Keep artifacts for 7 days (adjust as needed)

--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -14,10 +14,10 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v4
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'temurin'
         cache: 'gradle' # Cache Gradle dependencies based on Java version
 


### PR DESCRIPTION
This workflow builds a debug APK on pushes to master and pull requests targeting master.

It includes steps for:
- Checking out code
- Setting up JDK 11
- Setting up Gradle (with caching)
- Building the :app:assembleDebug target
- Uploading the resulting app-debug.apk as an artifact.