### PR TITLE
Feat: Enable dark mode support for the main app theme

### DIFF
--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="Theme.Childproofer" parent="android:Theme.Material.Light.NoActionBar" />
+    <style name="Theme.Childproofer" parent="Theme.MaterialComponents.DayNight.NoActionBar" />
 
     <style name="Theme.Childproofer.AppWidgetContainerParent" parent="@android:style/Theme.DeviceDefault">
         <!-- Radius of the outer bound of widgets to make the rounded corners -->


### PR DESCRIPTION
Changed the parent theme of the main application theme to `Theme.MaterialComponents.DayNight.NoActionBar`. This allows the app to automatically switch between light and dark themes based on the system setting, addressing the issue where the main screen always had a white background.