### PR TITLE
feat: Add support for Samsung devices

### DIFF
--- a/app/src/main/java/com/kacpersledz/child_proofer/MainActivity.kt
+++ b/app/src/main/java/com/kacpersledz/child_proofer/MainActivity.kt
@@ -47,6 +47,10 @@ class MainActivity : ComponentActivity() {
     // It's better practice to keep these helper functions in the Activity
     // so the Composable stays focused on UI.
 
+    private fun isSamsungDevice(): Boolean {
+        return android.os.Build.MANUFACTURER.equals("samsung", ignoreCase = true)
+    }
+
     private fun hasWriteSecureSettingsPermission(context: Context): Boolean {
         return ContextCompat.checkSelfPermission(
             context,
@@ -55,23 +59,39 @@ class MainActivity : ComponentActivity() {
     }
 
     private fun isTapGestureEnabled(context: Context): Boolean {
-        return Settings.Secure.getInt(context.contentResolver, "doze_tap_gesture", 0) == 1
+        return if (isSamsungDevice()) {
+            Settings.System.getInt(context.contentResolver, "double_tab_to_wake_up", 0) == 1
+        } else {
+            Settings.Secure.getInt(context.contentResolver, "doze_tap_gesture", 0) == 1
+        }
     }
 
     private fun setTapGestureEnabled(context: Context, enabled: Boolean) {
-        Settings.Secure.putInt(context.contentResolver, "doze_tap_gesture", if (enabled) 1 else 0)
+        if (isSamsungDevice()) {
+            Settings.System.putInt(context.contentResolver, "double_tab_to_wake_up", if (enabled) 1 else 0)
+        } else {
+            Settings.Secure.putInt(context.contentResolver, "doze_tap_gesture", if (enabled) 1 else 0)
+        }
     }
 
     private fun isLiftToWakeEnabled(context: Context): Boolean {
-        return Settings.Secure.getInt(context.contentResolver, "doze_pulse_on_pick_up", 0) == 1
+        return if (isSamsungDevice()) {
+            Settings.System.getInt(context.contentResolver, "lift_to_wake", 0) == 1
+        } else {
+            Settings.Secure.getInt(context.contentResolver, "doze_pulse_on_pick_up", 0) == 1
+        }
     }
 
     private fun setLiftToWakeEnabled(context: Context, enabled: Boolean) {
-        Settings.Secure.putInt(
-            context.contentResolver,
-            "doze_pulse_on_pick_up",
-            if (enabled) 1 else 0
-        )
+        if (isSamsungDevice()) {
+            Settings.System.putInt(context.contentResolver, "lift_to_wake", if (enabled) 1 else 0)
+        } else {
+            Settings.Secure.putInt(
+                context.contentResolver,
+                "doze_pulse_on_pick_up",
+                if (enabled) 1 else 0
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/kacpersledz/child_proofer/MainActivity.kt
+++ b/app/src/main/java/com/kacpersledz/child_proofer/MainActivity.kt
@@ -59,39 +59,27 @@ class MainActivity : ComponentActivity() {
     }
 
     private fun isTapGestureEnabled(context: Context): Boolean {
-        return if (isSamsungDevice()) {
-            Settings.Secure.getInt(context.contentResolver, "double_tab_to_wake_up", 0) == 1
-        } else {
-            Settings.Secure.getInt(context.contentResolver, "doze_tap_gesture", 0) == 1
-        }
+        val settingName = if (isSamsungDevice()) "double_tab_to_wake_up" else "doze_tap_gesture"
+        return Settings.Secure.getInt(context.contentResolver, settingName, 0) == 1
     }
 
     private fun setTapGestureEnabled(context: Context, enabled: Boolean) {
-        if (isSamsungDevice()) {
-            Settings.Secure.putInt(context.contentResolver, "double_tab_to_wake_up", if (enabled) 1 else 0)
-        } else {
-            Settings.Secure.putInt(context.contentResolver, "doze_tap_gesture", if (enabled) 1 else 0)
-        }
+        val settingName = if (isSamsungDevice()) "double_tab_to_wake_up" else "doze_tap_gesture"
+        Settings.Secure.putInt(context.contentResolver, settingName, if (enabled) 1 else 0)
     }
 
     private fun isLiftToWakeEnabled(context: Context): Boolean {
-        return if (isSamsungDevice()) {
-            Settings.Secure.getInt(context.contentResolver, "lift_to_wake", 0) == 1
-        } else {
-            Settings.Secure.getInt(context.contentResolver, "doze_pulse_on_pick_up", 0) == 1
-        }
+        val settingName = if (isSamsungDevice()) "lift_to_wake" else "doze_pulse_on_pick_up"
+        return Settings.Secure.getInt(context.contentResolver, settingName, 0) == 1
     }
 
     private fun setLiftToWakeEnabled(context: Context, enabled: Boolean) {
-        if (isSamsungDevice()) {
-            Settings.Secure.putInt(context.contentResolver, "lift_to_wake", if (enabled) 1 else 0)
-        } else {
-            Settings.Secure.putInt(
-                context.contentResolver,
-                "doze_pulse_on_pick_up",
-                if (enabled) 1 else 0
-            )
-        }
+        val settingName = if (isSamsungDevice()) "lift_to_wake" else "doze_pulse_on_pick_up"
+        Settings.Secure.putInt(
+            context.contentResolver,
+            settingName,
+            if (enabled) 1 else 0
+        )
     }
 }
 

--- a/app/src/main/java/com/kacpersledz/child_proofer/MainActivity.kt
+++ b/app/src/main/java/com/kacpersledz/child_proofer/MainActivity.kt
@@ -60,7 +60,7 @@ class MainActivity : ComponentActivity() {
 
     private fun isTapGestureEnabled(context: Context): Boolean {
         return if (isSamsungDevice()) {
-            Settings.System.getInt(context.contentResolver, "double_tab_to_wake_up", 0) == 1
+            Settings.Secure.getInt(context.contentResolver, "double_tab_to_wake_up", 0) == 1
         } else {
             Settings.Secure.getInt(context.contentResolver, "doze_tap_gesture", 0) == 1
         }
@@ -68,7 +68,7 @@ class MainActivity : ComponentActivity() {
 
     private fun setTapGestureEnabled(context: Context, enabled: Boolean) {
         if (isSamsungDevice()) {
-            Settings.System.putInt(context.contentResolver, "double_tab_to_wake_up", if (enabled) 1 else 0)
+            Settings.Secure.putInt(context.contentResolver, "double_tab_to_wake_up", if (enabled) 1 else 0)
         } else {
             Settings.Secure.putInt(context.contentResolver, "doze_tap_gesture", if (enabled) 1 else 0)
         }
@@ -76,7 +76,7 @@ class MainActivity : ComponentActivity() {
 
     private fun isLiftToWakeEnabled(context: Context): Boolean {
         return if (isSamsungDevice()) {
-            Settings.System.getInt(context.contentResolver, "lift_to_wake", 0) == 1
+            Settings.Secure.getInt(context.contentResolver, "lift_to_wake", 0) == 1
         } else {
             Settings.Secure.getInt(context.contentResolver, "doze_pulse_on_pick_up", 0) == 1
         }
@@ -84,7 +84,7 @@ class MainActivity : ComponentActivity() {
 
     private fun setLiftToWakeEnabled(context: Context, enabled: Boolean) {
         if (isSamsungDevice()) {
-            Settings.System.putInt(context.contentResolver, "lift_to_wake", if (enabled) 1 else 0)
+            Settings.Secure.putInt(context.contentResolver, "lift_to_wake", if (enabled) 1 else 0)
         } else {
             Settings.Secure.putInt(
                 context.contentResolver,


### PR DESCRIPTION
This commit introduces support for Samsung devices by using the correct setting names for "tap to wake" and "lift to wake".

The app now checks the device manufacturer and uses the following settings:
- For Samsung devices: `double_tab_to_wake_up` and `lift_to_wake` (from `Settings.System`)
- For all other devices: `doze_tap_gesture` and `doze_pulse_on_pick_up` (from `Settings.Secure`)